### PR TITLE
feat: support get repos type

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,17 @@ pnpm install del-repos -g
 -   Options
     -   `-v`，`--version` displays the version number
     -   `-h`，`--help` displays help information
+    -   `-t`, `o/a` get repositories type, default value `a` `(o: owner，a: all)`
+        -   How to specify the acquisition repositories type：
+        ```sh
+        # get all personal repositories
+        del-repos -t o
 
+        # Get all repositories (including collaborators and organization member repositories)
+        del-repos
+        # or
+        del-repos -t a
+        ```
 ### 🌟 using
 
 1. Select the platform (`GitHub` or `Gitee`).

--- a/README.zh.md
+++ b/README.zh.md
@@ -34,7 +34,17 @@ pnpm install del-repos -g
 -   选项
     -   `-v`, `--version` 显示版本号
     -   `-h`, `--help` 显示帮助信息
+    -   `-t`, `o/a` 获取仓库类型, 默认值 `a` `(o: owner，a: all)`
+        -   如何指定获取仓库类型
+        ```sh
+        # 获取个人所有仓库
+        del-repos -t o
 
+        # 获取所有仓库(包含合作者和组织成员仓库)
+        del-repos
+        # or
+        del-repos -t a
+        ```
 ### 🌟 使用
 
 1.  选择平台（`GitHub` 或 `Gitee`）。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "del-repos",
-    "version": "1.1.1",
+    "version": "1.1.2-alpha.0",
     "bin": {
         "del-repos": "dist/index.js"
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { fetchGithubRepos, deleteGithubRepos } from './services/github';
 import { fetchGiteeRepos, deleteGiteeRepos } from './services/gitee';
 import { startSpinner, stopSpinner } from './utils/spinner';
 import { readFileSync } from 'fs';
+import { reposType } from './utils';
 import { join } from 'path';
 
 const packageJsonPath = join(__dirname, '../package.json');
@@ -19,8 +20,14 @@ const argv = yargs(hideBin(process.argv))
     .alias('v', 'version')
     .help('h')
     .alias('h', 'help')
-    .epilog('For more information, visit https://github.com/yaolifeng0629/del-repos.git')
-    .argv;
+    .option('t', {
+        alias: 'type',
+        describe: '显示的仓库列表类型(o: owner, a: all)',
+        choices: ['o', 'a'], // 限制参数值为 'o': owner 或 'a': all
+        demandOption: false, // 是否可选参数
+        type: 'string',
+    })
+    .epilog('For more information, visit https://github.com/yaolifeng0629/del-repos.git').argv;
 
 const main = async () => {
     console.log(blue('Welcome to the Repository Deletion CLI Tool'));
@@ -35,12 +42,18 @@ const main = async () => {
 
     startSpinner('Fetching your repositories...');
 
+    /**
+     * 获取仓库类型
+     * @param t(type) 仓库类型: owner || all
+     */
+    const { t: type = 'a' } = await argv;
+
     try {
         let repos;
         if (platform === 'GitHub') {
-            repos = await fetchGithubRepos(token);
+            repos = await fetchGithubRepos(token, reposType(type));
         } else {
-            repos = await fetchGiteeRepos(token);
+            repos = await fetchGiteeRepos(token, reposType(type));
         }
 
         stopSpinner('Fetched repositories successfully.');

--- a/src/services/gitee.ts
+++ b/src/services/gitee.ts
@@ -4,7 +4,14 @@ import { extractPath } from '../utils';
 
 const GITEE_API_BASE = 'https://gitee.com/api/v5';
 
-export const fetchGiteeRepos = async (token: string) => {
+/**
+ * 获取 Gitee 仓库
+ * @param token Gitee token
+ * @param type 仓库类型: owner || all
+ * @returns 仓库列表
+ */
+
+export const fetchGiteeRepos = async (token: string, type: string) => {
     let page = 1;
     let repos: {
         html_url: string;
@@ -16,15 +23,15 @@ export const fetchGiteeRepos = async (token: string) => {
     while (hasMore) {
         const response = await axios.get(`${GITEE_API_BASE}/user/repos`, {
             headers: {
-                Authorization: `token ${token}`
+                Authorization: `token ${token}`,
             },
             params: {
-                type: 'all',
+                type: type,
                 sort: 'updated',
                 direction: 'desc',
                 page,
-                per_page: 100
-            }
+                per_page: 100,
+            },
         });
         repos = repos.concat(response.data);
         hasMore = response.data.length === 100;
@@ -34,6 +41,12 @@ export const fetchGiteeRepos = async (token: string) => {
     return repos.map(repo => `${repo.full_name} \u001b]8;;${repo.html_url}\u0007🔗\u001b]8;;\u0007`);
 };
 
+/**
+ * 删除 Gitee 仓库
+ * @param token Gitee token
+ * @param repos 待删除的仓库
+ * @returns 删除结果
+ */
 export const deleteGiteeRepos = async (token: string, repos: string[]) => {
     const spinner = ora();
     let username = '';
@@ -41,8 +54,8 @@ export const deleteGiteeRepos = async (token: string, repos: string[]) => {
     try {
         const response = await axios.get(`${GITEE_API_BASE}/user`, {
             headers: {
-                Authorization: `token ${token}`
-            }
+                Authorization: `token ${token}`,
+            },
         });
         username = response.data.login;
     } catch (error) {
@@ -58,14 +71,14 @@ export const deleteGiteeRepos = async (token: string, repos: string[]) => {
             const deleteUrl = `${GITEE_API_BASE}/repos/${username}/${repo}?access_token=${token}`;
             await axios.get(deleteUrl, {
                 headers: {
-                    Authorization: `token ${token}`
-                }
+                    Authorization: `token ${token}`,
+                },
             });
             // more information: https://gitee.com/api/v5/swagger#/deleteV5ReposOwnerRepo
             await axios.delete(deleteUrl, {
                 headers: {
-                    Authorization: `token ${token}`
-                }
+                    Authorization: `token ${token}`,
+                },
             });
 
             spinner.succeed(`Deleted repository ${repo}.`);

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -4,7 +4,13 @@ import { extractPath } from '../utils';
 
 const GITHUB_API_BASE = 'https://api.github.com';
 
-export const fetchGithubRepos = async (token: string) => {
+/**
+ * 获取 Github 仓库
+ * @param token Github token
+ * @param type 仓库类型: owner || all
+ * @returns 仓库列表
+ */
+export const fetchGithubRepos = async (token: string, type: string) => {
     let page = 1;
     let repos: {
         html_url: string;
@@ -16,15 +22,15 @@ export const fetchGithubRepos = async (token: string) => {
         // more information: https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repositories-for-the-authenticated-user
         const response = await axios.get(`${GITHUB_API_BASE}/user/repos`, {
             headers: {
-                Authorization: `token ${token}`
+                Authorization: `token ${token}`,
             },
             params: {
-                type: 'all',
+                type: type,
                 sort: 'updated',
                 direction: 'desc',
                 page,
-                per_page: 100
-            }
+                per_page: 100,
+            },
         });
         repos = repos.concat(response.data);
         hasMore = response.data.length === 100;
@@ -34,6 +40,12 @@ export const fetchGithubRepos = async (token: string) => {
     return repos.map(repo => `${repo.full_name} \u001b]8;;${repo.html_url}\u0007🔗\u001b]8;;\u0007`);
 };
 
+/**
+ * 删除 Github 仓库
+ * @param token Github token
+ * @param repos 待删除的仓库
+ * @returns 删除结果
+ */
 export const deleteGithubRepos = async (token: string, repos: string[]) => {
     const spinner = ora();
     let username = '';
@@ -41,8 +53,8 @@ export const deleteGithubRepos = async (token: string, repos: string[]) => {
     try {
         const response = await axios.get(`${GITHUB_API_BASE}/user`, {
             headers: {
-                Authorization: `token ${token}`
-            }
+                Authorization: `token ${token}`,
+            },
         });
         username = response.data.login;
     } catch (error) {
@@ -59,14 +71,14 @@ export const deleteGithubRepos = async (token: string, repos: string[]) => {
             // more information: https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#get-a-repository
             await axios.get(deleteUrl, {
                 headers: {
-                    Authorization: `token ${token}`
-                }
+                    Authorization: `token ${token}`,
+                },
             });
             // more information: https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#delete-a-repository
             await axios.delete(deleteUrl, {
                 headers: {
-                    Authorization: `token ${token}`
-                }
+                    Authorization: `token ${token}`,
+                },
             });
 
             spinner.succeed(`Deleted repository ${repo}.`);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,3 +12,11 @@ export const extractPath = (input: string): string => {
 
     return result;
 };
+
+export const reposType = (type: string): string => {
+    const map = new Map([
+        ['o', 'owner'],
+        ['a', 'all'],
+    ]);
+    return map.get(type) || 'all';
+};


### PR DESCRIPTION
### Support get repos type
-  You can install the `1.1.2-alpha.0`  version to experience it
- Details: 
	-	add Option: 
		-   `-t`, `o/a` get repositories type, default value `a` `(o: owner，a: all)` 

-   How to specify the acquisition repositories type：
```sh
# get all personal repositories
del-repos -t o

# Get all repositories (including collaborators and organization member repositories)
del-repos
# or
del-repos -t a
```